### PR TITLE
Adapt findContours code to be agnostic to OpenCV version

### DIFF
--- a/PCandWebcam/5-contours.py
+++ b/PCandWebcam/5-contours.py
@@ -22,8 +22,12 @@ while (True):
     mask = cv2.inRange(image_HSV,lower_pink,upper_pink)
     mask = cv2.GaussianBlur(mask,(5,5),0)
 
-    # findContours returns a list of the outlines of the white shapes in the mask (and a heirarchy that we shall ignore)            
-    derp,contours, hierarchy = cv2.findContours(mask,cv2.RETR_TREE,cv2.CHAIN_APPROX_SIMPLE)
+    # findContours returns a list of the outlines of the white shapes in the mask (and a hierarchy that we shall ignore)
+    # API differences:
+    #   OpenCV 2.x: findContours -> contours, hierarchy
+    #   OpenCV 3.x: findContours -> image, contours, hierarchy
+    #   OpenCV 4.x: findContours -> contours, hierarchy
+    contours, hierarchy = cv2.findContours(mask,cv2.RETR_TREE,cv2.CHAIN_APPROX_SIMPLE)[-2:]
 
     # contours is a list, and each element is a set of coordinates for points on the boundary of an object 'join the dots' style.
     # we can draw the contours with the following command

--- a/PCandWebcam/6-target.py
+++ b/PCandWebcam/6-target.py
@@ -23,7 +23,11 @@ while (True):
     mask = cv2.GaussianBlur(mask,(5,5),0)
 
     # findContours returns a list of the outlines of the white shapes in the mask (and a heirarchy that we shall ignore)            
-    derp,contours, hierarchy = cv2.findContours(mask,cv2.RETR_TREE,cv2.CHAIN_APPROX_SIMPLE)
+    # API differences:
+    #   OpenCV 2.x: findContours -> contours, hierarchy
+    #   OpenCV 3.x: findContours -> image, contours, hierarchy
+    #   OpenCV 4.x: findContours -> contours, hierarchy
+    contours, hierarchy = cv2.findContours(mask,cv2.RETR_TREE,cv2.CHAIN_APPROX_SIMPLE)[-2:]
 
     # If we have at least one contour, look through each one and pick the biggest
     if len(contours)>0:

--- a/RaspberryPi/5-contours.py
+++ b/RaspberryPi/5-contours.py
@@ -26,8 +26,12 @@ while (True):
     mask = cv2.inRange(image_HSV,lower_pink,upper_pink)
     mask = cv2.GaussianBlur(mask,(5,5),0)
 
-    # findContours returns a list of the outlines of the white shapes in the mask (and a heirarchy that we shall ignore)            
-    contours, hierarchy = cv2.findContours(mask,cv2.RETR_TREE,cv2.CHAIN_APPROX_SIMPLE)
+    # findContours returns a list of the outlines of the white shapes in the mask (and a hierarchy that we shall ignore)
+    # API differences:
+    #   OpenCV 2.x: findContours -> contours, hierarchy
+    #   OpenCV 3.x: findContours -> image, contours, hierarchy
+    #   OpenCV 4.x: findContours -> contours, hierarchy
+    contours, hierarchy = cv2.findContours(mask,cv2.RETR_TREE,cv2.CHAIN_APPROX_SIMPLE)[-2:]
 
     # contours is a list, and each element is a set of coordinates for points on the boundary of an object 'join the dots' style.
     # we can draw the contours with the following command

--- a/RaspberryPi/6-target.py
+++ b/RaspberryPi/6-target.py
@@ -27,7 +27,11 @@ while (True):
     mask = cv2.GaussianBlur(mask,(5,5),0)
 
     # findContours returns a list of the outlines of the white shapes in the mask (and a heirarchy that we shall ignore)            
-    contours, hierarchy = cv2.findContours(mask,cv2.RETR_TREE,cv2.CHAIN_APPROX_SIMPLE)
+    # API differences:
+    #   OpenCV 2.x: findContours -> contours, hierarchy
+    #   OpenCV 3.x: findContours -> image, contours, hierarchy
+    #   OpenCV 4.x: findContours -> contours, hierarchy
+    contours, hierarchy = cv2.findContours(mask,cv2.RETR_TREE,cv2.CHAIN_APPROX_SIMPLE)[-2:]
 
     # If we have at least one contour, look through each one and pick the biggest
     if len(contours)>0:


### PR DESCRIPTION
2.x returned contours, hierarchy; 3.x also returned the image; 4.x
switches back to not returning the image.